### PR TITLE
vm->flag_permanence to avoid mrbc_vm_end() if it's an IRB etc.

### DIFF
--- a/src/rrt0.c
+++ b/src/rrt0.c
@@ -552,7 +552,7 @@ int mrbc_run(void)
       tcb->state = TASKSTATE_DORMANT;
       q_insert_task(tcb);
       hal_enable_irq();
-      mrbc_vm_end(&tcb->vm);
+      if (tcb->vm.flag_permanence) mrbc_vm_end(&tcb->vm);
 
 #if MRBC_SCHEDULER_EXIT
       if( q_ready_ == NULL && q_waiting_ == NULL &&

--- a/src/vm.c
+++ b/src/vm.c
@@ -1441,6 +1441,11 @@ static inline int op_return( mrbc_vm *vm, mrbc_value *regs )
 {
   FETCH_B();
 
+  if (vm->flag_permanence == 1 && vm->callinfo_tail == NULL) {
+    regs[0] = regs[a];
+    return -1;
+  }
+
   mrbc_decref(&regs[0]);
   regs[0] = regs[a];
   regs[a].tt = MRBC_TT_EMPTY;

--- a/src/vm.h
+++ b/src/vm.h
@@ -114,6 +114,7 @@ typedef struct VM {
 
   volatile int8_t flag_preemption;
   int8_t flag_need_memfree;
+  int8_t flag_permanence;
 } mrbc_vm;
 typedef struct VM mrb_vm;
 


### PR DESCRIPTION
WIP: ivar still does not work while lvar works